### PR TITLE
Fix internal links

### DIFF
--- a/src/concepts/graphs.md
+++ b/src/concepts/graphs.md
@@ -1,6 +1,6 @@
 # Graphs
 
-Graphs are our canvas for building things in NodeScript. They can contain many connected [nodes](./nodes), each performing a specific task or function. By combining nodes in a Graph, you can build complex applications of your logic. 
+Graphs are our canvas for building things in NodeScript. They can contain many connected [nodes](./nodes.md), each performing a specific task or function. By combining nodes in a Graph, you can build complex applications of your logic.
 
 You'll use the Graph to interact with, create, and manage your workflows or applications by linking nodes in different ways. They are infinitely scrollable and are the main place you will interact with NodeScript. You can zoom in and out of the Graph to orientate yourself.
 

--- a/src/concepts/nodes.md
+++ b/src/concepts/nodes.md
@@ -13,7 +13,7 @@ The inputs can be identified by the shape (the triangle towards the right), and 
 There are two types of Nodes that you should understand the difference of:
 
  - **Standard Library** - these nodes cannot have their behaviour changed, they are provided by NodeScript. They provide the foundation to build more complex graphs.
- - **Modules** - these are covered in more detail [here](./modules), but succinctly they are ways of calling other graphs that perform their own logic.
+ - **Modules** - these are covered in more detail [here](./modules.md), but succinctly they are ways of calling other graphs that perform their own logic.
 
 ## Adding Nodes to a Graph
 

--- a/src/concepts/workspaces.md
+++ b/src/concepts/workspaces.md
@@ -12,7 +12,7 @@ Use the Workspace menu to access your workspace `Settings`, click through to `Me
 
 ## Creating and managing endpoints
 
-You can find all your endpoints in the `Endpoints` sidebar. Endpoints can be very powerful and flexible, as you can see [here](./endpoints). Before relying on NodeScript for production applications, take some time to plan out your endpoints carefully
+You can find all your endpoints in the `Endpoints` sidebar. Endpoints can be very powerful and flexible, as you can see [here](./endpoints.md). Before relying on NodeScript for production applications, take some time to plan out your endpoints carefully
 
 ## Managing your workspace name
 


### PR DESCRIPTION
Fixing internal links.
They worked in development but not in production. In production they were redirecting to the home page.
It is reproducible running the docker container.

Using file extension for links as recommended here:
https://vuepress.vuejs.org/guide/markdown.html#links